### PR TITLE
Add server port config environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ For Minecraft Java Edition you'll need to use this image instead:
 The following environment variables will set the equivalent property in `server.properties`, where each [is described here](https://minecraft.gamepedia.com/Server.properties#Bedrock_Edition_3).
 
 - `SERVER_NAME`
+- `SERVER_PORT`
 - `GAMEMODE`
 - `DIFFICULTY`
 - `LEVEL_TYPE`

--- a/property-definitions.json
+++ b/property-definitions.json
@@ -2,6 +2,9 @@
   "server-name": {
     "env": "SERVER_NAME"
   },
+  "server-port": {
+    "env": "SERVER_PORT"
+  },
   "gamemode": {
     "env": "GAMEMODE",
     "allowed": ["survival","creative","adventure"],


### PR DESCRIPTION
Added ability to configure the server listening port via environment variable. If a nonstandard port is mapped in docker (e.g. 20000:19132/udp) then the client will connect to the server however status information is not properly displayed to the client. Explicitly setting the server listening port and doing a direct mapping to the alternate port (e.g. 20000:20000/udp) will allow the client to properly show the server status information. This is useful when running multiple server instances on different ports via docker-compose.