### PR TITLE
Adding example backup and restore to/from AWS S3

### DIFF
--- a/examples/kubernetes-backup-to-s3.yaml
+++ b/examples/kubernetes-backup-to-s3.yaml
@@ -1,3 +1,10 @@
+# WARNING: This does not currently account for the potential of the world being saved in 
+#   the middle of a change to the files on disk. The only protection is choosing a time 
+#   for backups that is unlikely to be in use. 
+#
+# NOTE: The save command may be a way around this and is under investigation:
+#   https://minecraft.gamepedia.com/Commands/save
+
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/examples/kubernetes-backup-to-s3.yaml
+++ b/examples/kubernetes-backup-to-s3.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backup-to-s3-bedrock
+  labels:
+    role: backup
+data:
+  # https://github.com/flickerfly/docker-backup-to-s3/blob/master/README.md
+  CRON_SCHEDULE: '0 12 * * *'
+  S3_PATH: s3://mybucket/bedrock/
+  AWS_DEFAULT_REGION: us-east-1
+  # Pass this to the S3 command
+  PARAMS: ""
+  PREFIX: bedrock
+  DATA_PATH: /data/
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backup-to-s3-bedrock
+  labels:
+    role: backup
+data:
+  # https://github.com/flickerfly/docker-backup-to-s3/blob/master/README.md
+  AES_PASSPHRASE: BASE64-ENCODED STRING
+  AWS_ACCESS_KEY_ID: BASE64-ENCODED STRING
+  AWS_SECRET_ACCESS_KEY: BASE64-ENCODED STRING 
+
+---
+# Setup the Deployment of a pod that will do the work.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bds-backup
+  labels:
+    role: backup
+    app: bedrock
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      role: backup
+      app: bedrock
+  template:
+    metadata:
+      labels:
+        app: bedrock
+        role: backup
+    spec:
+      containers:
+        - name: backup-to-s3
+          image: jritchie/backup-to-s3
+          args: 
+            - schedule
+          volumeMounts:
+            - name: bds
+              mountPath: /data
+          envFrom:
+            - configMapRef:
+                name: backup-to-s3-bedrock
+            - secretRef:
+                name: backup-to-s3-bedrock
+      volumes:
+        - name: bds
+          persistentVolumeClaim:
+            claimName: bds
+            readOnly: true

--- a/examples/kubernetes-restore-to-s3.yaml
+++ b/examples/kubernetes-restore-to-s3.yaml
@@ -1,4 +1,10 @@
-# IMPORTANT: Be sure to set the VERSION variable in the Job definition with the name of the backup file to be restored in S3
+# IMPORTANT: Be sure to set the VERSION variable in the Job definition 
+#   with the name of the backup file to be restored in S3
+#
+# WARNING: It is best practice to scale down your minecraft deployment
+#   to assure you have no server pods running before a restore. This is 
+#   currenly a manual task.
+
 ---
 apiVersion: v1
 kind: Namespace

--- a/examples/kubernetes-restore-to-s3.yaml
+++ b/examples/kubernetes-restore-to-s3.yaml
@@ -1,0 +1,84 @@
+# IMPORTANT: Be sure to set the VERSION variable in the Job definition with the name of the backup file to be restored in S3
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+   name: minecraft
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: bds
+  namespace: minecraft
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backup-to-s3-bedrock
+  namespace: minecraft
+  labels:
+    role: backup
+data:
+  # https://github.com/flickerfly/docker-backup-to-s3/blob/master/README.md
+  CRON_SCHEDULE: '0 12 * * *'
+  S3_PATH: s3://mybucket/bedrock
+  AWS_DEFAULT_REGION: us-east-1
+  # Pass this to the S3 command
+  PARAMS: ""
+  PREFIX: bedrock
+  DATA_PATH: /data/
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backup-to-s3-bedrock
+  namespace: minecraft
+  labels:
+    role: backup
+data:
+  # https://github.com/flickerfly/docker-backup-to-s3/blob/master/README.md
+  AES_PASSPHRASE: BASE64-ENCODED STRING
+  AWS_ACCESS_KEY_ID: BASE64-ENCODED STRING
+  AWS_SECRET_ACCESS_KEY: BASE64-ENCODED STRING
+
+---
+# Setup the jod to create a pod that will do the work.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: bds-restore
+  namespace: minecraft
+  labels:
+    role: restore
+    app: bedrock
+spec:
+  template:
+    spec:
+      containers:
+        - name: restore-from-s3
+          image: jritchie/backup-to-s3
+          args: 
+            - restore
+          volumeMounts:
+            - name: bds
+              mountPath: /data
+          envFrom:
+            - configMapRef:
+                name: backup-to-s3-bedrock
+            - secretRef:
+                name: backup-to-s3-bedrock
+          env:
+            - name: VERSION
+              value: bedrck-3020-05-28T15:33:49Z-example
+      restartPolicy: Never
+      volumes:
+        - name: bds
+          persistentVolumeClaim:
+            claimName: bds


### PR DESCRIPTION
Provides backup and restore examples using S3 in a Kubernetes environment and is at least a partial fix to #53. 