### PR TITLE
Moves configuration in k8s example to a ConfigMap

### DIFF
--- a/examples/kubernetes.yml
+++ b/examples/kubernetes.yml
@@ -1,4 +1,33 @@
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: minecraft-bedrock
+  labels:
+    role: service-config
+    app: bds
+data:
+  # Find more options at https://github.com/itzg/docker-minecraft-bedrock-server#server-properties
+  # Remove # from in front of line if changing from default values.
+  EULA: "TRUE" # Must accept EULA to use this minecraft server
+  #GAMEMODE: survival # Options: survival, creative, adventure
+  #DIFFICULTY: easy # Options: peaceful, easy, normal, hard
+  #DEFAULT_PLAYER_PERMISSION_LEVEL: member # Options: visitor, member, operator
+  #LEVEL_NAME: my_minecraft_world
+  #LEVEL_SEED: "33480944"
+  #SERVER_NAME: my_minecraft_server
+  #WHITE_LIST: false # If enabled, need to provide a whitelist.json by your own means. 
+  #SERVER_PORT: 19132
+  #LEVEL_TYPE: DEFAULT # Options: FLAT, LEGACY, DEFAULT
+  #ALLOW_CHEATS: false # Options: true, false
+  #MAX_PLAYERS: 10
+  #ONLINE_MODE: true # Options: true, false (removes Xbox Live account requirements)
+  #TEXTUREPACK_REQUIRED: false # Options: true, false
+  #VIEW_DISTANCE: 10
+  #TICK_DISTANCE: 4
+  #PLAYER_IDLE_TIMEOUT: 30
+  #MAX_THREADS: 8
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -28,13 +57,9 @@ spec:
         - name: bds
           image: itzg/minecraft-bedrock-server
           imagePullPolicy: Always
-          env:
-            - name: EULA
-              value: "TRUE"
-            - name: GAMEMODE
-              value: survival
-            - name: DIFFICULTY
-              value: normal
+          envFrom:
+            - configMapRef:
+                name: minecraft-bedrock
           volumeMounts:
             - mountPath: /data
               name: data

--- a/examples/kubernetes.yml
+++ b/examples/kubernetes.yml
@@ -10,23 +10,27 @@ data:
   # Find more options at https://github.com/itzg/docker-minecraft-bedrock-server#server-properties
   # Remove # from in front of line if changing from default values.
   EULA: "TRUE" # Must accept EULA to use this minecraft server
-  #GAMEMODE: survival # Options: survival, creative, adventure
-  #DIFFICULTY: easy # Options: peaceful, easy, normal, hard
-  #DEFAULT_PLAYER_PERMISSION_LEVEL: member # Options: visitor, member, operator
-  #LEVEL_NAME: my_minecraft_world
+  #GAMEMODE: "survival" # Options: survival, creative, adventure
+  #DIFFICULTY: "easy" # Options: peaceful, easy, normal, hard
+  #DEFAULT_PLAYER_PERMISSION_LEVEL: "member" # Options: visitor, member, operator
+  #LEVEL_NAME: "my_minecraft_world"
   #LEVEL_SEED: "33480944"
-  #SERVER_NAME: my_minecraft_server
-  #WHITE_LIST: false # If enabled, need to provide a whitelist.json by your own means. 
-  #SERVER_PORT: 19132
-  #LEVEL_TYPE: DEFAULT # Options: FLAT, LEGACY, DEFAULT
-  #ALLOW_CHEATS: false # Options: true, false
-  #MAX_PLAYERS: 10
-  #ONLINE_MODE: true # Options: true, false (removes Xbox Live account requirements)
-  #TEXTUREPACK_REQUIRED: false # Options: true, false
-  #VIEW_DISTANCE: 10
-  #TICK_DISTANCE: 4
-  #PLAYER_IDLE_TIMEOUT: 30
-  #MAX_THREADS: 8
+  #SERVER_NAME: "my_minecraft_server"
+  #SERVER_PORT: "19132"
+  #LEVEL_TYPE: "DEFAULT" # Options: FLAT, LEGACY, DEFAULT
+  #ALLOW_CHEATS: "false" # Options: true, false
+  #MAX_PLAYERS: "10"
+  #PLAYER_IDLE_TIMEOUT: "30"
+  #TEXTUREPACK_REQUIRED: "false" # Options: true, false
+  #
+  ## Changing these will have a security impact
+  #ONLINE_MODE: "true" # Options: true, false (removes Xbox Live account requirements)
+  #WHITE_LIST: "false" # If enabled, need to provide a whitelist.json by your own means. 
+  #
+  ## Changing these will have a performance impact
+  #VIEW_DISTANCE: "10"
+  #TICK_DISTANCE: "4"
+  #MAX_THREADS: "8"
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/examples/kubernetes.yml
+++ b/examples/kubernetes.yml
@@ -104,7 +104,6 @@ spec:
   ports:
     - port: 19132
       protocol: UDP
-  type: LoadBalancer
   ipFamily: IPv4
   # Use LoadBalancer if running on a provider that supports that
 #  type: LoadBalancer


### PR DESCRIPTION
This adds a ConfigMap for the environment variables for the kubernetes example, fleshes those out with more info about how to customize it and applies it to the deployment in the example. It is really more about easily documenting configuration. The comments in the ConfigMap manifest are removed when pushed into k8s. 