### PR TITLE
Added bedrock v 1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ For Minecraft Java Edition you'll need to use this image instead:
   - `1.12` : the latest version of 1.12
   - `1.13` : the latest version of 1.13
   - `1.14` : the latest version of 1.14
+  - `1.16` : the latest version of 1.16
 - `UID` (default derived from `/data` owner) : can be set to a specific user ID to run the
   bedrock server process
 - `GID` (default derived from `/data` owner) : can be set to a specific group ID to run the

--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -27,6 +27,9 @@ case ${VERSION} in
   1.14)
     VERSION=1.14.60.5
     ;;
+  1.16)
+    VERSION=1.16.0.2
+    ;;
   *)
     for a in data-bi-prtid data-platform; do
       DOWNLOAD_URL=$(restify --attribute=${a}=serverBedrockLinux ${downloadPage} 2> /tmp/restify.out | jq -r '.[0].href' || echo '')


### PR DESCRIPTION
The new Bedrock 1.16 was released today. This PR adds that to the list of versions.