### PR TITLE
Update bedrock-entry.sh to overwrite all existing game files except config files

### DIFF
--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -71,8 +71,8 @@ if [ ! -f "bedrock_server-${VERSION}" ]; then
     fi
   done
 
-  # ... use -n to avoid overwriting any existing files with the archive's copy
-  unzip -n -q ${TMP_ZIP}
+  # ... overwrite all game files, except config files
+  unzip -q ${TMP_ZIP} -x server.properties whitelist.json permissions.json
   rm ${TMP_ZIP}
 
   chmod +x bedrock_server


### PR DESCRIPTION
The old unzip -n option used when unzipping newer BDS versions was causing some required files in the updated dist to not to be updated, resulting in buggy mixed version. It's a known issue that happens when only the bedrock_server binary is copied without the rest.

Changed it to copy everything, except for a few sample config files included in the dist that would otherwise overwrite the users local changes. I think I have the correct set (server.properties, whitelist.json, permissions.json), but I don't actually play this game so I'm not 100% sure.