### PR TITLE
updating bedrock script to write whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ in the "LAN Games" part of the "Friends" tab, such as:
 
 The whitelist works with player names. The server will look up the names and add in the XUID to match the player.
 
-```yaml
-whitelist: player1,player2,player3
+```shell
+-e WHITELIST "player1,player2,player3"
 ```
 
 ## More information

--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ in the "LAN Games" part of the "Friends" tab, such as:
 
 ![](docs/example-client.jpg)
 
+## Whitelist
+
+The whitelist works with player names. The server will look up the names and add in the XUID to match the player.
+
+```yaml
+whitelist: player1,player2,player3
+```
+
 ## More information
 
 For more information about managing Bedrock Dedicated Servers in general, [check out this Reddit post](https://old.reddit.com/user/ProfessorValko/comments/9f438p/bedrock_dedicated_server_tutorial/).

--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -94,6 +94,14 @@ if [ ! -f "bedrock_server-${VERSION}" ]; then
   mv bedrock_server bedrock_server-${VERSION}
 fi
 
+if [ -n "$WHITE_LIST" ]; then
+  echo "Setting whitelist"
+  rm -rf whitelist.json
+  echo $WHITE_LIST | awk -v RS=, 'BEGIN{print "["}; {print "{ \"name\": \"" $1 "\" },"}; END{print "]"}' > whitelist.json
+  # flag whitelist to true so the server properties process correctly
+  export WHITE_LIST=true
+fi
+
 set-property --file server.properties --bulk /etc/bds-property-definitions.json
 
 export LD_LIBRARY_PATH=.


### PR DESCRIPTION
This doesn't set a XUID for the players. I'm keeping it this way so it matches java edition and seems easier. The downside is that it will smash the whitelist on each boot and, thus, nuke the XUIDs that are written to the file. I don't think this is a big deal, but worth noting.