### PR TITLE
Adding permissions.json creation to bedrock server startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,24 @@ in the "LAN Games" part of the "Friends" tab, such as:
 
 ![](docs/example-client.jpg)
 
+## Permissions
+
+The Bedrock Dedicated Server requires permissions be defined with XUIDs. There are various tools to look these up online and they
+are also printed to the log when a player joins. There are 3 levels of permissions and 3 options to configure each group:
+
+- `OPS` is used to define operators on the server.  
+```shell
+-e OPS "1234567890,0987654321"
+```
+- `MEMBERS` is used to define the members on the server.
+```shell
+-e MEMBERS "1234567890,0987654321"
+```
+- `VISITORS` is used to define visitors on the server.
+```shell
+-e VISITORS "1234567890,0987654321"
+```
+
 ## More information
 
 For more information about managing Bedrock Dedicated Servers in general, [check out this Reddit post](https://old.reddit.com/user/ProfessorValko/comments/9f438p/bedrock_dedicated_server_tutorial/).

--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -94,6 +94,21 @@ if [ ! -f "bedrock_server-${VERSION}" ]; then
   mv bedrock_server bedrock_server-${VERSION}
 fi
 
+if [ -n "$OPS" ] || [ -n "$MEMBERS" ] || [ -n "$VISITORS" ]; then
+  echo "Updating permissions"
+  echo "[" > permissions.json
+  if [ -n "$OPS" ]; then
+    echo $OPS | awk -v RS=, '{print "{ \"permission\": \"operator\", \"xuid\": \"" $1 "\" },"}' >> permissions.json
+  fi
+  if [ -n "$MEMBERS" ]; then
+    echo $MEMBERS | awk -v RS=, '{print "{ \"permission\": \"member\", \"xuid\": \"" $1 "\" },"}' >> permissions.json
+  fi
+  if [ -n "$VISITORS" ]; then
+    echo $VISITORS | awk -v RS=, '{print "{ \"permission\": \"visitor\", \"xuid\": \"" $1 "\" },"}' >> permissions.json
+  fi
+  echo "]" >> permissions.json
+fi
+
 set-property --file server.properties --bulk /etc/bds-property-definitions.json
 
 export LD_LIBRARY_PATH=.


### PR DESCRIPTION
This will use env variables for ops, members, and visitors to generate a permissions.json file at startup. It will smash it on each start of the container.