### PR TITLE
Updating whitelist environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,13 @@ are also printed to the log when a player joins. There are 3 levels of permissio
 
 ## Whitelist
 
-The whitelist works with player names. The server will look up the names and add in the XUID to match the player.
+There are two ways to handle a whitelist. The first is to set the `WHITE_LIST` environment variable to true and map
+in a whitelist.json that is custom-crafted to the container. The other is to use the `WHITE_LIST_USERS` environment
+variable to list users that should be whitelisted. This list is player names. The server will look up the names and
+add in the XUID to match the player.
 
 ```shell
--e WHITE_LIST "player1,player2,player3"
+-e WHITE_LIST_USERS "player1,player2,player3"
 ```
 
 ## More information

--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -109,10 +109,10 @@ if [ -n "$OPS" ] || [ -n "$MEMBERS" ] || [ -n "$VISITORS" ]; then
   echo "]" >> permissions.json
 fi
 
-if [ -n "$WHITE_LIST" ]; then
+if [ -n "$WHITE_LIST_USERS" ]; then
   echo "Setting whitelist"
   rm -rf whitelist.json
-  echo $WHITE_LIST | awk -v RS=, 'BEGIN{print "["}; {print "{ \"name\": \"" $1 "\" },"}; END{print "]"}' > whitelist.json
+  echo $WHITE_LIST_USERS | awk -v RS=, 'BEGIN{print "["}; {print "{ \"name\": \"" $1 "\" },"}; END{print "]"}' > whitelist.json
   # flag whitelist to true so the server properties process correctly
   export WHITE_LIST=true
 fi


### PR DESCRIPTION
WHITE_LIST_USERS is now used to list users instead of WHITE_LIST to prevent eclipsing original behavior. This allows setting WHITE_LIST to true/false if mapping in a whitelist.json file.

Fixes #103 