### PR TITLE
Issues with downloading new server version - suggested fix

### DIFF
--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -40,16 +40,19 @@ case ${VERSION^^} in
     ;;
   LATEST)
     for a in data-bi-prtid data-platform; do
-      DOWNLOAD_URL=$(restify --attribute=${a}=serverBedrockLinux ${downloadPage} 2> restify.err | jq -r '.[0].href' || echo '')
-      if [[ ${DOWNLOAD_URL} ]]; then
-        break
-      fi
+      for i in {1..3}; do
+        DOWNLOAD_URL=$(restify --attribute=${a}=serverBedrockLinux ${downloadPage} 2> restify.err | jq -r '.[0].href' || echo '')
+        if [[ ${DOWNLOAD_URL} ]]; then
+          break 2
+        fi
+      done
     done
     if [[ ${DOWNLOAD_URL} =~ http.*/.*-(.*)\.zip ]]; then
       VERSION=${BASH_REMATCH[1]}
-    elif [[ $(ls bedrock_server-* 2> /dev/null|head -1) =~ bedrock_server-(.*) ]]; then
+    elif [[ $(ls -rv bedrock_server-* 2> /dev/null|head -1) =~ bedrock_server-(.*) ]]; then
       VERSION=${BASH_REMATCH[1]}
       echo "WARN Minecraft download page failed, so using existing download of $VERSION"
+      cat restify.err
     else
       echo "Failed to extract download URL '${DOWNLOAD_URL}' from ${downloadPage}"
       cat restify.err


### PR DESCRIPTION
This is a proposed fix for https://github.com/itzg/docker-minecraft-bedrock-server/issues/123. 

It makes 3 small changes:

- sort existing server binaries via 'reverse version' order - to get true latest release
- tries 3 times to locate each of the searched-for data attributes to try and tolerate transient network errors
- logs output of restify.err in case of download failure but with existing binary, for future diag

It seems to be very reliable compared to my other containers (which use the standard image). The fixed one has not failed to start at latest version whereas the others are wrong most days. Maybe something weird with my network reliability but at least this fix seems to deal with it.

I've put the retries inside the data-attribute iteration. We could equally do it the other way around.