### PR TITLE
k8s: Enable tty/stdin

### DIFF
--- a/examples/kubernetes.yml
+++ b/examples/kubernetes.yml
@@ -84,6 +84,8 @@ spec:
                 - 127.0.0.1
             initialDelaySeconds: 30
           livenessProbe: *probe
+          tty: true
+          stdin: true
   volumeClaimTemplates:
     - metadata:
         name: data


### PR DESCRIPTION
Enable tty and stdin for Kubernetes deployment to be able to
attach management console.
