### PR TITLE
Temp directory is configurable but defaults to /tmp

### DIFF
--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-: "${TMP_DIR:=/data/tmp}"
+: "${TMP_DIR:=/tmp}"
 
 if [[ ${DEBUG^^} = TRUE ]]; then
   set -x


### PR DESCRIPTION
Temp directory didn't need to be under `/data`, but it's still configurable

https://discord.com/channels/660567679458869252/660569755320844308/985588097381187594