### PR TITLE
Arm64 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM debian
 
 # ARCH is only set to avoid repetition in Dockerfile since the binary download only supports amd64
-ARG ARCH=amd64
+ARG ARCH=arm64
+# ARG ARCH=arm64
 
 ARG APT_UPDATE=20210112
 
@@ -10,8 +11,17 @@ RUN apt-get update && \
     curl \
     unzip \
     jq \
+	debian-keyring \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# Instal box64
+RUN curl -L https://ryanfortner.github.io/box64-debs/box64.list -o /etc/apt/sources.list.d/box64.list && \
+    curl -L https://ryanfortner.github.io/box64-debs/KEY.gpg | gpg --dearmor | tee /usr/share/keyrings/box64-debs-archive-keyring.gpg && \
+	apt-get update && \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y box64 \
+		&& apt-get clean \
+		&& rm -rf /var/lib/apt/lists/*
 
 EXPOSE 19132/udp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM debian
 
-# ARCH is only set to avoid repetition in Dockerfile since the binary download only supports amd64
-ARG ARCH=arm64
-# ARG ARCH=arm64
+# ARCH is only set to avoid repetition in Dockerfile, use --build-arg ARCH=arm64 for arm cpu
+ARG ARCH=amd64
 
 ARG APT_UPDATE=20210112
 
@@ -11,17 +10,20 @@ RUN apt-get update && \
     curl \
     unzip \
     jq \
-	debian-keyring \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Instal box64
-RUN curl -L https://ryanfortner.github.io/box64-debs/box64.list -o /etc/apt/sources.list.d/box64.list && \
-    curl -L https://ryanfortner.github.io/box64-debs/KEY.gpg | gpg --dearmor | tee /usr/share/keyrings/box64-debs-archive-keyring.gpg && \
+# Instal box64 on arm
+RUN if [ "$ARCH" = "arm64" ] ; then \
+	apt-get update && \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y debian-keyring && \
+	curl -L https://ryanfortner.github.io/box64-debs/box64.list -o /etc/apt/sources.list.d/box64.list && \
+    curl -L https://ryanfortner.github.io/box64-debs/KEY.gpg | gpg --dearmor > /usr/share/keyrings/box64-debs-archive-keyring.gpg && \
 	apt-get update && \
 	DEBIAN_FRONTEND=noninteractive apt-get install -y box64 \
 		&& apt-get clean \
-		&& rm -rf /var/lib/apt/lists/*
+		&& rm -rf /var/lib/apt/lists/* ;\
+	fi
 
 EXPOSE 19132/udp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,15 @@ RUN apt-get update && \
 
 # Instal box64 on arm
 RUN if [ "$ARCH" = "arm64" ] ; then \
-	apt-get update && \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y debian-keyring && \
-	curl -L https://ryanfortner.github.io/box64-debs/box64.list -o /etc/apt/sources.list.d/box64.list && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y debian-keyring && \
+    curl -L https://ryanfortner.github.io/box64-debs/box64.list -o /etc/apt/sources.list.d/box64.list && \
     curl -L https://ryanfortner.github.io/box64-debs/KEY.gpg | gpg --dearmor > /usr/share/keyrings/box64-debs-archive-keyring.gpg && \
-	apt-get update && \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y box64 \
-		&& apt-get clean \
-		&& rm -rf /var/lib/apt/lists/* ;\
-	fi
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y box64 \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/* ;\
+    fi
 
 EXPOSE 19132/udp
 

--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -159,4 +159,8 @@ set-property --file server.properties --bulk /etc/bds-property-definitions.json
 export LD_LIBRARY_PATH=.
 
 echo "Starting Bedrock server..."
-exec box64 ./bedrock_server-${VERSION}
+if [ -f /usr/local/bin/box64 ] ; then
+	exec box64 ./bedrock_server-${VERSION}
+else
+	exec ./bedrock_server-${VERSION}
+fi

--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -160,7 +160,7 @@ export LD_LIBRARY_PATH=.
 
 echo "Starting Bedrock server..."
 if [ -f /usr/local/bin/box64 ] ; then
-	exec box64 ./bedrock_server-${VERSION}
+    exec box64 ./bedrock_server-${VERSION}
 else
-	exec ./bedrock_server-${VERSION}
+    exec ./bedrock_server-${VERSION}
 fi

--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -159,4 +159,4 @@ set-property --file server.properties --bulk /etc/bds-property-definitions.json
 export LD_LIBRARY_PATH=.
 
 echo "Starting Bedrock server..."
-exec ./bedrock_server-${VERSION}
+exec box64 ./bedrock_server-${VERSION}


### PR DESCRIPTION
For the past few days, I've been playing with the server running in a Kubernetes node on a raspberry pi 4. The performance seems better or as good as my old coreduo 2 server.

This change:
When the docker image is built with `--build-arg ARCH=arm64`, it will conditionally install box64 and run the bedrock-server with it.