### PR TITLE
Fixes GPG issues with box64-deps for ARM64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN if [ "$ARCH" = "arm64" ] ; then \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y debian-keyring && \
     curl -L https://ryanfortner.github.io/box64-debs/box64.list -o /etc/apt/sources.list.d/box64.list && \
-    curl -L https://ryanfortner.github.io/box64-debs/KEY.gpg | gpg --dearmor > /usr/share/keyrings/box64-debs-archive-keyring.gpg && \
+    curl -L https://ryanfortner.github.io/box64-debs/KEY.gpg | gpg --dearmor | tee /etc/apt/trusted.gpg.d/box64-debs-archive-keyring.gpg && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y box64 \
         && apt-get clean \


### PR DESCRIPTION
On with ARCH=arm64 the Docker build currently fails. 
This PR changes the way the GPG keyring is installed for the box64-deps according to https://github.com/ryanfortner/box64-debs#repository-installation. 

I guess this is needed because of an update of the Debian base image.