### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,10 +50,10 @@ COPY property-definitions.json /etc/bds-property-definitions.json
 COPY bin/* /usr/local/bin/
 
 # Available versions listed at
-# https://minecraft.gamepedia.com/Bedrock_Edition_1.11.0
-# https://minecraft.gamepedia.com/Bedrock_Edition_1.12.0
-# https://minecraft.gamepedia.com/Bedrock_Edition_1.13.0
-# https://minecraft.gamepedia.com/Bedrock_Edition_1.14.0
+# https://minecraft.wiki/w/Bedrock_Edition_1.11.0
+# https://minecraft.wiki/w/Bedrock_Edition_1.12.0
+# https://minecraft.wiki/w/Bedrock_Edition_1.13.0
+# https://minecraft.wiki/w/Bedrock_Edition_1.14.0
 ENV VERSION=LATEST \
     SERVER_PORT=19132
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ For Minecraft Java Edition you'll need to use this image instead:
 
 ### Server Properties
 
-The following environment variables will set the equivalent property in `server.properties`, where each [is described here](https://minecraft.gamepedia.com/Server.properties#Bedrock_Edition_3).
+The following environment variables will set the equivalent property in `server.properties`, where each [is described here](https://minecraft.wiki/w/Server.properties#Bedrock_Edition_3).
 
 - `SERVER_NAME`
 - `SERVER_PORT`
@@ -148,7 +148,7 @@ are also printed to the log when a player joins. There are 3 levels of permissio
 
 There are two ways to handle a whitelist:
 
-The first is to set the `ALLOW_LIST` environment variable to true and map in an [allowlist.json](https://minecraft.gamepedia.com/Whitelist.json) file (previously known as "whitelist.json") that is custom-crafted to the container. 
+The first is to set the `ALLOW_LIST` environment variable to true and map in an [allowlist.json](https://minecraft.wiki/w/Whitelist.json) file (previously known as "whitelist.json") that is custom-crafted to the container. 
 
 The other is to set the `ALLOW_LIST_USERS` environment variable to a comma-separated list of gamer tag usernames that should be allowed. The server will look up the names and add in the XUID to match the player.
 

--- a/examples/kubernetes-backup-to-s3.yaml
+++ b/examples/kubernetes-backup-to-s3.yaml
@@ -3,7 +3,7 @@
 #   for backups that is unlikely to be in use. 
 #
 # NOTE: The save command may be a way around this and is under investigation:
-#   https://minecraft.gamepedia.com/Commands/save
+#   https://minecraft.wiki/w/Commands/save
 
 ---
 apiVersion: v1


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.