### PR TITLE
Add Timezone to Container Specific Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ For Minecraft Java Edition you'll need to use this image instead:
   bedrock server process
 - `GID` (default derived from `/data` owner) : can be set to a specific group ID to run the
   bedrock server process
+- `TZ` (no default): can be set to a specific timezone like `America/New_York`. This will set the timezone for the Docker container and therefore their logs. Addtionally, if you want to sync the time with the host, you can mount the `/etc/localtime` file from the host to the container like `/etc/localtime:/etc/localtime:ro`.
 - `PACKAGE_BACKUP_KEEP` (`2`) : how many package backups to keep
 
 ### Server Properties


### PR DESCRIPTION
Hi. I have added instructions for `TZ` to Container Specific section.

This will ensure the logs display the desired timezone.