### PR TITLE
Updates to Allow/White List handling

### DIFF
--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -175,11 +175,11 @@ if [[ -n "$ALLOW_LIST_USERS" || -n "$WHITE_LIST_USERS" ]]; then
     ALLOW_LIST=true
   else
     ALLOW_LIST=false
-    rm allowlist.json
+    rm -f allowlist.json
   fi
 else
   ALLOW_LIST=false
-  rm allowlist.json
+  rm -f allowlist.json
 fi
 sed -i '/^white-list=.*/d' server.properties #Removes white-list= line from server.properties
 export ALLOW_LIST

--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -165,22 +165,20 @@ if [ -n "$OPS" ] || [ -n "$MEMBERS" ] || [ -n "$VISITORS" ]; then
   ]| flatten' > permissions.json
 fi
 
+if [[ -v ALLOW_LIST_USERS ]]; then
+  allowListUsers=${ALLOW_LIST_USERS}
 
-if [[ -v ALLOW_LIST_USERS || -v WHITE_LIST_USERS ]]; then
-  allowListUsers=${ALLOW_LIST_USERS:-${WHITE_LIST_USERS}}
-
-  WHITE_LIST=false
-  rm -f whitelist.json
-  if [[ $allowListUsers ]]; then
+  if [[ "$allowListUsers" ]]; then
     echo "Setting allow list"
     jq -c -n --arg users "$allowListUsers" '$users | split(",") | map({"ignoresPlayerLimit":false,"name": .})' > "allowlist.json"
     # activate server property to enable list usage
     ALLOW_LIST=true
   else
-    rm -rf allowlist.json
+    rm -f allowlist.json
+    # deactivate server property if no allow list is specified
     ALLOW_LIST=false
   fi
-  export WHITE_LIST ALLOW_LIST
+  export ALLOW_LIST
 fi
 
 set-property --file server.properties --bulk /etc/bds-property-definitions.json

--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -165,8 +165,8 @@ if [ -n "$OPS" ] || [ -n "$MEMBERS" ] || [ -n "$VISITORS" ]; then
   ]| flatten' > permissions.json
 fi
 
-if [[ -v ALLOW_LIST_USERS ]]; then
-  allowListUsers=${ALLOW_LIST_USERS}
+if [[ -n "$ALLOW_LIST_USERS" || -n "$WHITE_LIST_USERS" ]]; then
+  allowListUsers=${ALLOW_LIST_USERS:-$WHITE_LIST_USERS}
 
   if [[ "$allowListUsers" ]]; then
     echo "Setting allow list"
@@ -174,12 +174,15 @@ if [[ -v ALLOW_LIST_USERS ]]; then
     # activate server property to enable list usage
     ALLOW_LIST=true
   else
-    rm -f allowlist.json
-    # deactivate server property if no allow list is specified
     ALLOW_LIST=false
+    rm allowlist.json
   fi
-  export ALLOW_LIST
+else
+  ALLOW_LIST=false
+  rm allowlist.json
 fi
+
+export ALLOW_LIST
 
 set-property --file server.properties --bulk /etc/bds-property-definitions.json
 

--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -181,7 +181,7 @@ else
   ALLOW_LIST=false
   rm allowlist.json
 fi
-
+sed -i '/^white-list=.*/d' server.properties #Removes white-list= line from server.properties
 export ALLOW_LIST
 
 set-property --file server.properties --bulk /etc/bds-property-definitions.json


### PR DESCRIPTION
If the ALLOW_LIST_USERS or WHITE_LIST_USERS env variables were set, the existing code would append white-list=false to server.properties, which resulted in conflicting variables (allow-list=true , white-list=false). Because the variable is still currently supported, it would result in inconsistent behavior from the server.

This commit removes all reference to the white-list variable, as support for it is being deprecated by Microsoft and also includes omission of the WHITE_LIST=false line.