### PR TITLE
fixes issues with moving out existing resource packs to backup folder

### DIFF
--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -129,12 +129,16 @@ if [ ! -f "bedrock_server-${VERSION}" ]; then
   bkupDir=backup-pre-${VERSION}
   # fixup any previous interrupted upgrades
   rm -rf "${bkupDir}"
-  for d in behavior_packs definitions minecraftpe resource_packs structures treatments world_templates
-  do
-    if [ -d $d ]; then
-      mkdir -p $bkupDir
+  for d in behavior_packs definitions minecraftpe resource_packs structures treatments world_templates; do
+    if [[ -d $d && -n "$(ls $d)" ]]; then
+      mkdir -p $bkupDir/$d
       echo "Backing up $d into $bkupDir"
-      mv $d $bkupDir
+      if [[ "$d" == "resource_packs" ]]; then
+        mv $d/{chemistry,vanilla} $bkupDir/
+        [[ -n "$(ls $d)" ]] && cp -a $d/* $bkupDir/
+      else
+        mv $d/* $bkupDir/
+      fi
     fi
   done
 


### PR DESCRIPTION
Currently on each new server version, the custom resource_packs are moved out of the resource_packs folder and have to be manually moved back.

this PR fixes the issue