### PR TITLE
handle username and XUID for ALLOW_LIST_USERS

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,12 @@ There are two ways to handle a whitelist:
 
 The first is to set the `ALLOW_LIST` environment variable to true and map in an [allowlist.json](https://minecraft.wiki/w/Whitelist.json) file (previously known as "whitelist.json") that is custom-crafted to the container. 
 
-The other is to set the `ALLOW_LIST_USERS` environment variable to a comma-separated list of gamer tag usernames that should be allowed. The server will look up the names and add in the XUID to match the player.
+The other is to set the `ALLOW_LIST_USERS` environment variable to a comma-separated list of gamer tag usernames and their corresponding XUIDs. Each username should be followed by its XUID, separated by a colon. The server will use these details to match the player.
+
+There are various tools to look XUIDs up online and they are also printed to the log when a player joins the server.
 
 ```shell
--e ALLOW_LIST_USERS="player1,player2,player3"
+-e ALLOW_LIST_USERS="player1:1234567890,player2:0987654321"
 ```
 
 ## Mods Addons 

--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -163,7 +163,7 @@ if [[ -n "$OPS" || -n "$MEMBERS" || -n "$VISITORS" ]]; then
 fi
 
 if [[ -n "$ALLOW_LIST_USERS" || -n "$WHITE_LIST_USERS" ]]; then
-  allowListUsers=$(echo "${ALLOW_LIST_USERS:-$WHITE_LIST_USERS}" | tr -d '\n' | tr -d '\r')
+  allowListUsers=${ALLOW_LIST_USERS:-$WHITE_LIST_USERS}
 
   if [[ "$allowListUsers" ]]; then
     echo "Setting allow list"

--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -163,11 +163,15 @@ if [[ -n "$OPS" || -n "$MEMBERS" || -n "$VISITORS" ]]; then
 fi
 
 if [[ -n "$ALLOW_LIST_USERS" || -n "$WHITE_LIST_USERS" ]]; then
-  allowListUsers=${ALLOW_LIST_USERS:-$WHITE_LIST_USERS}
+  allowListUsers=$(echo "${ALLOW_LIST_USERS:-$WHITE_LIST_USERS}" | tr -d '\n' | tr -d '\r')
 
   if [[ "$allowListUsers" ]]; then
     echo "Setting allow list"
-    jq -c -n --arg users "$allowListUsers" '$users | split(",") | map({"ignoresPlayerLimit":false,"name": .})' > "allowlist.json"
+    if [[ "$allowListUsers" != *":"* ]]; then
+      jq -c -n --arg users "$allowListUsers" '$users | split(",") | map({"ignoresPlayerLimit":false,"name": .})' > "allowlist.json"
+    else
+      jq -c -n --arg users "$allowListUsers" '$users | split(",") | map(split(":") | {"ignoresPlayerLimit":false,"name": .[0], "xuid": .[1]})' > "allowlist.json"
+    fi
     # activate server property to enable list usage
     ALLOW_LIST=true
   else


### PR DESCRIPTION
This is an attempt to workaround the issue with the XUID not being available in the allowlist.json as detailed https://github.com/itzg/docker-minecraft-bedrock-server/issues/336 
As the XUID is required for setting permissions I felt this was a potential approach here.