### PR TITLE
Ssh remote console

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,11 @@ RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --var version=${MC_MONITOR_VERSION} --var app=mc-monitor --file {{.app}} \
   --from ${GITHUB_BASEURL}/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 
+ARG MC_SERVER_RUNNER_VERSION=1.10.0
+RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
+  --var version=${MC_SERVER_RUNNER_VERSION} --var app=mc-server-runner --file {{.app}} \
+  --from ${GITHUB_BASEURL}/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
+
 COPY *.sh /opt/
 
 COPY property-definitions.json /etc/bds-property-definitions.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,13 @@ ARG TARGETVARIANT
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \
     curl \
+    openssl \
     unzip \
     jq \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Instal box64 on arm
+# Install box64 on arm
 RUN if [ "$TARGETARCH" = "arm64" ] ; then \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y debian-keyring && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN if [ "$TARGETARCH" = "arm64" ] ; then \
     curl -L https://ryanfortner.github.io/box64-debs/box64.list -o /etc/apt/sources.list.d/box64.list && \
     curl -L https://ryanfortner.github.io/box64-debs/KEY.gpg | gpg --dearmor | tee /etc/apt/trusted.gpg.d/box64-debs-archive-keyring.gpg && \
     apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y box64-generic-arm \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y box64-arm64 \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/* ;\
     fi

--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -193,6 +193,10 @@ export LD_LIBRARY_PATH=.
 mcServerRunnerArgs=()
 if isTrue "${ENABLE_SSH}"; then
   mcServerRunnerArgs+=(--remote-console)
+  if ! [[ -v RCON_PASSWORD ]]; then
+    RCON_PASSWORD=$(openssl rand -hex 12)
+    export RCON_PASSWORD
+  fi
 fi
 
 echo "Starting Bedrock server..."

--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -190,9 +190,14 @@ set-property --file server.properties --bulk /etc/bds-property-definitions.json
 
 export LD_LIBRARY_PATH=.
 
+mcServerRunnerArgs=()
+if isTrue "${ENABLE_SSH}"; then
+  mcServerRunnerArgs+=(--remote-console)
+fi
+
 echo "Starting Bedrock server..."
 if [[ -f /usr/local/bin/box64 ]] ; then
-    exec box64 ./"bedrock_server-${VERSION}"
+    exec mc-server-runner "${mcServerRunnerArgs[@]}" box64 ./"bedrock_server-${VERSION}"
 else
-    exec ./"bedrock_server-${VERSION}"
+    exec mc-server-runner "${mcServerRunnerArgs[@]}" ./"bedrock_server-${VERSION}"
 fi

--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -50,6 +50,8 @@ if [[ ${DEBUG^^} == TRUE ]]; then
   echo "       current directory is $(pwd)"
 fi
 
+export HOME=/data
+
 downloadPage=https://www.minecraft.net/en-us/download/server/bedrock
 
 if [[ ${EULA^^} != TRUE ]]; then
@@ -197,6 +199,11 @@ if isTrue "${ENABLE_SSH}"; then
     RCON_PASSWORD=$(openssl rand -hex 12)
     export RCON_PASSWORD
   fi
+
+  # For ssh access by tools, export the current password.
+  # Use rcon's format to align with Java, as Java uses the rcon password for SSH as well.
+  echo "password=${RCON_PASSWORD}" > "$HOME/.rcon-cli.env"
+  echo "password: \"${RCON_PASSWORD}\"" > "$HOME/.rcon-cli.yaml"
 fi
 
 echo "Starting Bedrock server..."

--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -202,8 +202,8 @@ if isTrue "${ENABLE_SSH}"; then
 
   # For ssh access by tools, export the current password.
   # Use rcon's format to align with Java, as Java uses the rcon password for SSH as well.
-  echo "password=${RCON_PASSWORD}" > "$HOME/.rcon-cli.env"
-  echo "password: \"${RCON_PASSWORD}\"" > "$HOME/.rcon-cli.yaml"
+  echo "password=${RCON_PASSWORD}" > "$HOME/.remote-console.env"
+  echo "password: \"${RCON_PASSWORD}\"" > "$HOME/.remote-console.yaml"
 fi
 
 echo "Starting Bedrock server..."


### PR DESCRIPTION
## Purpose 

This enables the work that was started in the mc-server-runner pull request to add a remote SSH console. 
https://github.com/itzg/mc-server-runner/pull/56

- Adds mc-server-runner and openssl to the container
- Adds `ENABLE_SSH` setting 
- Fixes box64 pkg that got renamed
- Ensures that if `RCON_PASSWORD` is not set, that it uses a scrambled password to match the docker-minecraft-server behavior.

## Validation Performed

Built the docker container locally on an ARM64 system (M1 Mac mini with an Ubuntu VM running docker). Started a server with ENABLE_SSH set and the 2222 port exposed. Was able to login from a standard ssh client and issue commands to it. Docker logs were checked and confirmed that the output was sent to both locations and I could audit SSH connections. 

Also checked to make sure that the default 'minecraft' password did not work if RCON_PASSWORD is not set. 

Checked to ensure that the server still works when ENABLE_SSH is not defined, and logs still work. 