### PR TITLE
Enchancement: Added msa-gamertags-only, disable-custom-skins, op-permission-level and more.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ For Minecraft Java Edition you'll need to use this image instead:
 ### Server Properties
 
 The following environment variables will set the equivalent property in `server.properties`, where each [is described here](https://minecraft.wiki/w/Server.properties#Option_keys).
+Got it, here's the list with each item surrounded by backticks and prefixed with a hyphen:
 
+```
 - `SERVER_NAME`
 - `SERVER_PORT`
 - `SERVER_PORT_V6`
@@ -78,6 +80,15 @@ The following environment variables will set the equivalent property in `server.
 - `PLAYER_MOVEMENT_DISTANCE_THRESHOLD`
 - `PLAYER_MOVEMENT_DURATION_THRESHOLD_IN_MS`
 - `CORRECT_PLAYER_MOVEMENT`
+- `MSA_GAMERTAGS_ONLY`
+- `ITEM_TRANSACTION_LOGGING_ENABLED`
+- `DISABLE_CUSTOM_SKINS`
+- `DISABLE_PERSONA`
+- `CHAT_RESTRICTION`
+- `OP_PERMISSION_LEVEL`
+- `COMPRESSION_ALGORITHM`
+- `BLOCK_NETWORK_IDS_ARE_HASHES`
+```
 
 For example, to configure a flat, creative server instead of the default use:
 

--- a/property-definitions.json
+++ b/property-definitions.json
@@ -10,7 +10,7 @@
   },
   "gamemode": {
     "env": "GAMEMODE",
-    "allowed": ["survival","creative","adventure"],
+    "allowed": ["survival", "creative", "adventure"],
     "mappings": {
       "0": "survival",
       "1": "creative",
@@ -19,11 +19,11 @@
   },
   "force-gamemode": {
     "env": "FORCE_GAMEMODE",
-    "allowed": ["true","false"]
+    "allowed": ["true", "false"]
   },
   "difficulty": {
     "env": "DIFFICULTY",
-    "allowed": ["easy","peaceful","normal","hard"],
+    "allowed": ["easy", "peaceful", "normal", "hard"],
     "mappings": {
       "0": "peaceful",
       "1": "easy",
@@ -33,7 +33,7 @@
   },
   "level-type": {
     "env": "LEVEL_TYPE",
-    "allowed": ["DEFAULT","FLAT","LEGACY"],
+    "allowed": ["DEFAULT", "FLAT", "LEGACY"],
     "mappings": {
       "flat": "FLAT",
       "legacy": "LEGACY",
@@ -42,22 +42,22 @@
   },
   "allow-cheats": {
     "env": "ALLOW_CHEATS",
-    "allowed": ["true","false"]
+    "allowed": ["true", "false"]
   },
   "max-players": {
     "env": "MAX_PLAYERS"
   },
   "online-mode": {
     "env": "ONLINE_MODE",
-    "allowed": ["true","false"]
+    "allowed": ["true", "false"]
   },
   "white-list": {
     "env": "WHITE_LIST",
-    "allowed": ["true","false"]
+    "allowed": ["true", "false"]
   },
   "allow-list": {
     "env": "ALLOW_LIST",
-    "allowed": ["true","false"]
+    "allowed": ["true", "false"]
   },
   "view-distance": {
     "env": "VIEW_DISTANCE"
@@ -82,15 +82,15 @@
   },
   "default-player-permission-level": {
     "env": "DEFAULT_PLAYER_PERMISSION_LEVEL",
-    "allowed": ["visitor","member","operator"]
+    "allowed": ["visitor", "member", "operator"]
   },
   "texturepack-required": {
     "env": "TEXTUREPACK_REQUIRED",
-    "allowed": ["true","false"]
+    "allowed": ["true", "false"]
   },
   "server-authoritative-movement": {
     "env": "SERVER_AUTHORITATIVE_MOVEMENT",
-    "allowed": ["server-auth","client-auth","server-auth-with-rewind"],
+    "allowed": ["server-auth", "client-auth", "server-auth-with-rewind"],
     "mappings": {
       "true": "server-auth",
       "false": "client-auth"
@@ -111,14 +111,50 @@
   },
   "correct-player-movement": {
     "env": "CORRECT_PLAYER_MOVEMENT",
-    "allowed": ["true","false"]
+    "allowed": ["true", "false"]
   },
   "emit-server-telemetry": {
     "env": "EMIT_SERVER_TELEMETRY",
-    "allowed": ["true","false"]
+    "allowed": ["true", "false"]
   },
   "enable-lan-visibility": {
     "env": "ENABLE_LAN_VISIBILITY",
-    "allowed": ["true","false"]
+    "allowed": ["true", "false"]
+  },
+  "msa-gamertags-only": {
+    "env": "MSA_GAMERTAGS_ONLY",
+    "allowed": ["true", "false"]
+  },
+  "item-transaction-logging-enabled": {
+    "env": "ITEM_TRANSACTION_LOGGING_ENABLED",
+    "allowed": ["true", "false"]
+  },
+  "disable-custom-skins": {
+    "env": "DISABLE_CUSTOM_SKINS",
+    "allowed": ["true", "false"]
+  },
+  "disable-persona": {
+    "env": "DISABLE_PERSONA",
+    "allowed": ["true", "false"]
+  },
+  "chat-restriction": {
+    "env": "CHAT_RESTRICTION",
+    "allowed": ["None", "Dropped", "Disabled"],
+    "mappings": {
+      "none": "none",
+      "dropped": "Dropped",
+      "disabled": "Disabled"
+    }
+  },
+  "op-permission-level": {
+    "env": "OP_PERMISSION_LEVEL"
+  },
+  "compression-algorithm": {
+    "env": "COMPRESSION_ALGORITHM",
+    "allowed": ["zlib", "snappy"]
+  },
+  "block-network-ids-are-hashes": {
+    "env": "BLOCK_NETWORK_IDS_ARE_HASHES",
+    "allowed": ["true", "false"]
   }
 }


### PR DESCRIPTION
Added some of the missing server properties to the `property-definitions.json`, I've also added them to the readme.

## New `server.properties`
- `msa-gamertags-only`: Controls whether only MSA gamertags are allowed.
  - **Allowed values:** `"true"` or `"false"`

- `item-transaction-logging-enabled`: Enables or disables logging for item transactions.
  - **Allowed values:** `"true"` or `"false"`

- `disable-custom-skins`: Disables the use of custom skins.
  - **Description:** If true, players cannot use skins customized outside of the Minecraft store or in-game assets.
  - **Allowed values:** `"true"` or `"false"`

- `disable-persona`: Disables persona features.
  - **Allowed values:** `"true"` or `"false"`

- `chat-restriction`: Sets chat restriction levels (None, Dropped, Disabled).
  - **Allowed values:** `"None"`, `"Dropped"`, `"Disabled"`
  - **Description:**
    - `"None"` allows regular free chat.
    - `"Dropped"` drops chat messages without sending them to any client.
    - `"Disabled"` hides the chat UI unless the player is an operator.

- `op-permission-level`: Configures the permission level for operators.
  - **Allowed values:** `2`, `3`, `4`
  - **Description:** 
    - `2` - Member
    - `3` - Operator
    - `4` - Console

- `compression-algorithm`: Chooses the compression algorithm (zlib, snappy).
  - **Allowed values:** `"zlib"`, `"snappy"`

- `block-network-ids-are-hashes`: Determines if block network IDs should be hashed.
  - **Description:** If true, the server sends hashed block network IDs instead of sequential IDs.
  - **Allowed values:** `"true"` or `"false"`
