### PR TITLE
adding ssh option to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The following environment variables will set the equivalent property in `server.
 Typically, each property is configured instead by the UPPER_SNAKE_CASE equivalent. 
 
 - `SERVER_NAME`
+- `ENABLE_SSH`
 - `GAMEMODE`
 - `FORCE_GAMEMODE`
 - `DIFFICULTY`


### PR DESCRIPTION
i found that the ENABLE_SSH isn't documented in the README.