### PR TITLE
Fix #326: Document that IPv6 is required by Mojang

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ docker run -d -it --name bds-flat-creative \
 
 ## Exposed Ports
 
-- **UDP** 19132 : the Bedrock server port.
-  **NOTE** that you must append `/udp` when exposing the port, such as `-p 19132:19132/udp`
+- **UDP** 19132 : the Bedrock server port on IPv4 set by `SERVER_PORT`. The IPv6 port is not exposed by default.
+  **NOTE** that you must append `/udp` when exposing the port, such as `-p 19132:19132/udp` and both IPv4 and IPv6 must be enabled on your host machine.
 
 ## Volumes
 


### PR DESCRIPTION
IPv6 is required, see https://bugs.mojang.com/browse/BDS-19079 and https://github.com/itzg/docker-minecraft-bedrock-server/issues/326.

This PR attempts to document that without any significant changes to the structure of the README. It seems like the ports section is a reasonable place?

Here is a quick link to previous this change: https://github.com/josephdpurcell/docker-minecraft-bedrock-server/tree/feature/document-ipv6?tab=readme-ov-file#exposed-ports