### PR TITLE
Maintain directory structure on backup

### DIFF
--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -128,10 +128,10 @@ if [[ ! -f "bedrock_server-${VERSION}" ]]; then
       mkdir -p "${bkupDir}/$d"
       echo "Backing up $d into $bkupDir"
       if [[ "$d" == "resource_packs" ]]; then
-        mv $d/{chemistry,vanilla} "${bkupDir}/"
-        [[ -n "$(ls $d)" ]] && cp -a $d/* "${bkupDir}/"
+        mv $d/{chemistry,vanilla} "${bkupDir}/$d/"
+        cp -a $d/ "${bkupDir}/$d/"
       else
-        mv $d/* "${bkupDir}/"
+        mv $d "${bkupDir}/"
       fi
     fi
   done


### PR DESCRIPTION
Fixes #413

# Issue
Files moved/copied to backup folder had flattened directory structure.  This caused filename clashes between [behavior_packs/vanilla, resource_packs/vanilla] and [behavior_packs/chemistry, resource_packs/chemistry]. This was causing upgrades to fail at the first attempt as described in #413.  Because subsequent restart of container cleaned the partial backup with `rm -rf "${bkupDir}"` the filename clashes were resolved, but the backup was incomplete.

# Change summary
This PR ensures the backup directory structure mirrors the original structure of the Bedrock Server data folder so should resolve these directory / filename clashes.

