### PR TITLE
bypass user agent constraint of official server

### DIFF
--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -111,7 +111,10 @@ if [[ ! -f "bedrock_server-${VERSION}" ]]; then
   TMP_ZIP="$TMP_DIR/$(basename "${DOWNLOAD_URL}")"
 
   echo "Downloading Bedrock server version ${VERSION} ..."
-  if ! curl "${curlArgs[@]}" -o "${TMP_ZIP}" -A "itzg/minecraft-bedrock-server" -fsSL "${DOWNLOAD_URL}"; then
+
+  USER_AGENT="${USER_AGENT:-itzg/minecraft-bedrock-server}"
+
+  if ! curl "${curlArgs[@]}" -o "${TMP_ZIP}" -A "${USER_AGENT}" -fsSL "${DOWNLOAD_URL}"; then
     echo "ERROR failed to download from ${DOWNLOAD_URL}"
     echo "      Double check that the given VERSION is valid"
     exit 2


### PR DESCRIPTION
From 10/01, I have faced a trouble that I cannot start docker container. As a result of inspection, I found out that I cannot download application file without a user agent of browser. So, I changed the script to add user agent that was gotten from environment variable when curl command was executed.

Change:
- get user agent for curl command from environment variable