### PR TITLE
Fix: eliminated hardcoded URL for custom versions

### DIFF
--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -92,8 +92,13 @@ case ${VERSION^^} in
     ;;
   *)
     # use the given version exactly
-    echo "Using given version ${VERSION}"
-    lookupVersion serverBedrockLinux "${VERSION}"
+    if isTrue "$PREVIEW"; then
+      echo "Using given preview version ${VERSION}"
+      lookupVersion serverBedrockPreviewLinux "${VERSION}"
+    else
+      echo "Using given version ${VERSION}"
+      lookupVersion serverBedrockLinux "${VERSION}"
+    fi
     ;;
 esac
 


### PR DESCRIPTION
Old behavior: Custom versions used hardcoded download URL. this URL should be dynamically sourced using the lookupVersion command instead.

New behavior: lookupVersion takes a second parameter, version, and uses a simple sed replace to insert the version parameter into the download URL dynamically, if it was successfully found.

Also, removed old bedrock version shortcuts. This can be restored and modified to use the lookupVersion command to get the right URL if needed. It's unclear whether there's any active servers still running on legacy versions of bedrock (to this author).

Resolves #460