### PR TITLE
Force curl to use HTTP/1.1

### DIFF
--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -108,7 +108,7 @@ if [[ ! -f "bedrock_server-${VERSION}" ]]; then
   TMP_ZIP="$TMP_DIR/$(basename "${DOWNLOAD_URL}")"
 
   echo "Downloading Bedrock server version ${VERSION} ..."
-  if ! curl "${curlArgs[@]}" -o "${TMP_ZIP}" -A "itzg/minecraft-bedrock-server" -fsSL "${DOWNLOAD_URL}"; then
+  if ! curl --http1.1 "${curlArgs[@]}" -o "${TMP_ZIP}" -A "itzg/minecraft-bedrock-server" -fsSL "${DOWNLOAD_URL}"; then
     echo "ERROR failed to download from ${DOWNLOAD_URL}"
     echo "      Double check that the given VERSION is valid"
     exit 2


### PR DESCRIPTION
Fixing issue where curl is defaulting to HTTP/2 which isn't supported by the download server. 