### PR TITLE
fix: Use HTTP/1.1 for downloading server

### DIFF
--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -108,7 +108,7 @@ if [[ ! -f "bedrock_server-${VERSION}" ]]; then
   TMP_ZIP="$DOWNLOAD_DIR/$(basename "${DOWNLOAD_URL}")"
 
   echo "Downloading Bedrock server version ${VERSION} ..."
-  if ! curl "${curlArgs[@]}" -o "${TMP_ZIP}" -A "itzg/minecraft-bedrock-server" -fsSL "${DOWNLOAD_URL}"; then
+  if ! curl "${curlArgs[@]}" --http1.1 -o "${TMP_ZIP}" -A "itzg/minecraft-bedrock-server" -fsSL "${DOWNLOAD_URL}"; then
     echo "ERROR failed to download from ${DOWNLOAD_URL}"
     echo "      Double check that the given VERSION is valid"
     exit 2


### PR DESCRIPTION
Recently, downloads of the Minecraft Bedrock server have failed with the error `curl: (92) HTTP/2 stream 1 was not closed cleanly: INTERNAL_ERROR (err 2)`. This is due to recent versions of `curl` defaulting to HTTP/2 with invalid header options. The simplest workaround is to revert to HTTP/1.1 for the download request.