### PR TITLE
Change download agent string to fix download issue from minecraft.net

### DIFF
--- a/bedrock-entry.sh
+++ b/bedrock-entry.sh
@@ -108,7 +108,7 @@ if [[ ! -f "bedrock_server-${VERSION}" ]]; then
   TMP_ZIP="$DOWNLOAD_DIR/$(basename "${DOWNLOAD_URL}")"
 
   echo "Downloading Bedrock server version ${VERSION} ..."
-  if ! curl "${curlArgs[@]}" -o "${TMP_ZIP}" -A "itzg/minecraft-bedrock-server" -fsSL "${DOWNLOAD_URL}"; then
+  if ! curl "${curlArgs[@]}" -o "${TMP_ZIP}" -A "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; itzg/minecraft-bedrock-server)" -fsSL "${DOWNLOAD_URL}"; then
     echo "ERROR failed to download from ${DOWNLOAD_URL}"
     echo "      Double check that the given VERSION is valid"
     exit 2


### PR DESCRIPTION
Currentlly the docker fails to download new verison. 

Change download agent string to fix download issue from minecraft.net