### PR TITLE
Add DIRECT_DOWNLOAD_URL environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ For Minecraft Java Edition you'll need to use this image instead:
   bedrock server process
 - `TZ` (no default): can be set to a specific timezone like `America/New_York`. This will set the timezone for the Docker container and therefore their logs. Addtionally, if you want to sync the time with the host, you can mount the `/etc/localtime` file from the host to the container like `/etc/localtime:/etc/localtime:ro`.
 - `PACKAGE_BACKUP_KEEP` (`2`) : how many package backups to keep
+- `DIRECT_DOWNLOAD_URL` (no default): This environment variable can be used to provide a **direct download URL** for the Minecraft Bedrock server `.zip` file. When set, this URL will be used instead of attempting to automatically look up the download link from `minecraft.net`. This is particularly useful for CI/CD environments or when the automatic version lookup is temporarily broken due to website changes. Ensure the URL points directly to the `bedrock-server-VERSION.zip` file.
+
 
 ### Server Properties
 


### PR DESCRIPTION
This Pull Request introduces a new environment variable, DIRECT_DOWNLOAD_URL, to enhance the reliability of the Minecraft Bedrock server download process, especially in automated environments like CI/CD pipelines.

Problem Solved:
The existing logic for automatically looking up the Bedrock server download URL from minecraft.net (using restify and mc-bds-helper.vercel.app) is prone to breakage when the website's HTML structure changes. This leads to download failures (e.g., "Failed to locate data-platform element", "URL using bad/illegal format") and prevents the server from starting, causing instability in automated deployments and testing.

Solution Implemented:
When the DIRECT_DOWNLOAD_URL environment variable is set, the bedrock-entry.sh script will now bypass all automatic lookup mechanisms and use the provided URL directly to download the Bedrock server .zip file. This offers a robust fallback and a reliable way to ensure the server binary is acquired, regardless of minecraft.net's front-end changes.

The script will still attempt to extract the VERSION from the DIRECT_DOWNLOAD_URL if VERSION is not explicitly set, providing a convenient default.

Usage Notes:

Users can now specify DIRECT_DOWNLOAD_URL=https://www.minecraft.net/bedrockdedicatedserver/bin-linux/bedrock-server-1.21.84.1.zip (or any other direct link) to ensure a stable download.
This is particularly beneficial for CI/CD environments where manual intervention is not possible.
The existing VERSION variable still functions as before for auto-lookup, and can be combined with DIRECT_DOWNLOAD_URL if a specific VERSION is needed and a direct URL.
Impact:

Significantly improves the reliability of Bedrock server startup in non-interactive and automated contexts.
Provides a quick workaround for future minecraft.net scraping issues without requiring immediate image updates.
Testing:
This change has been tested locally in a setup simulating a remote Docker environment (Windows client -> Debian VM Docker Daemon) and shown to resolve the download issues. It is intended to improve CI/CD pipeline stability.