### PR TITLE
add `ENABLE_SSH` env var description to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For Minecraft Java Edition you'll need to use this image instead:
 - `TZ` (no default): can be set to a specific timezone like `America/New_York`. This will set the timezone for the Docker container and therefore their logs. Addtionally, if you want to sync the time with the host, you can mount the `/etc/localtime` file from the host to the container like `/etc/localtime:/etc/localtime:ro`.
 - `PACKAGE_BACKUP_KEEP` (`2`) : how many package backups to keep
 - `DIRECT_DOWNLOAD_URL` (no default): This environment variable can be used to provide a **direct download URL** for the Minecraft Bedrock server `.zip` file. When set, this URL will be used instead of attempting to automatically look up the download link from `minecraft.net`. This is particularly useful for CI/CD environments or when the automatic version lookup is temporarily broken due to website changes. Ensure the URL points directly to the `bedrock-server-VERSION.zip` file.
-- `ENABLE_SSH` (no default) : Enable remote console over SSH if this environment variable is set to "true".
+- `ENABLE_SSH` (default is `false`) : Enable remote console over SSH on port 2222 if this environment variable is set to `true`.
 
 
 ### Server Properties


### PR DESCRIPTION
This container supports `ENABLE_SSH` env var, but there is no description on README.
So, let me add the description.

https://github.com/itzg/docker-minecraft-bedrock-server/blob/5ec8f35287437365ef59ab65bb9f572c6c043a7a/bedrock-entry.sh#L271-L282