### PR TITLE
Skip Auto release workflow on forks

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   auto-release:
     runs-on: ubuntu-latest
+    if: github.repository == 'itzg/docker-minecraft-bedrock-server'
     permissions:
       # allow for creating releases/tags
       contents: write


### PR DESCRIPTION
The scheduled Auto release workflow has no repository guard, so its daily cron also fires on forks with Actions enabled, where it fails and sends the fork owner a daily failure notification email.

This adds the same repository gate that build.yml already uses, so the job is skipped everywhere except itzg/docker-minecraft-bedrock-server.

Fixes #662